### PR TITLE
add option to pass CloudStorage model to S3Helper::deleteFile()

### DIFF
--- a/src/helpers/S3Helper.php
+++ b/src/helpers/S3Helper.php
@@ -84,8 +84,9 @@ class S3Helper {
 	 * @throws Throwable
 	 */
 	public static function deleteFile(CloudStorage|int $storage, ?string $bucket = null):?int {
-		$storageModel = $storage;
-		if (is_int($storage) && null === $storageModel = CloudStorage::find()->where(['id' => $storage])->active()->one()) return null;
+		if (null === $storageModel = (is_int($storage))
+				?CloudStorage::find()->where(['id' => $storage])->active()->one()
+				:$storage) return null;
 		$storageModel->deleted = true;
 		$storageModel->save();
 

--- a/src/helpers/S3Helper.php
+++ b/src/helpers/S3Helper.php
@@ -78,18 +78,18 @@ class S3Helper {
 
 	/**
 	 * Метод для удаления файлов
-	 * @param int $storageId
+	 * @param CloudStorage|int $storage
 	 * @param string|null $bucket
 	 * @return int|null
 	 * @throws Throwable
 	 */
-	public static function deleteFile(int $storageId, ?string $bucket = null):?int {
-		/** @var CloudStorage $storage */
-		if (null === $storage = CloudStorage::find()->where(['id' => $storageId])->active()->one()) return null;
-		$storage->deleted = true;
-		$storage->save();
+	public static function deleteFile(CloudStorage|int $storage, ?string $bucket = null):?int {
+		$storageModel = $storage;
+		if (is_int($storage) && null === $storageModel = CloudStorage::find()->where(['id' => $storage])->active()->one()) return null;
+		$storageModel->deleted = true;
+		$storageModel->save();
 
-		(new S3())->deleteObject($storage->key, $bucket);
-		return $storage->id;
+		(new S3())->deleteObject($storageModel->key, $bucket);
+		return $storageModel->id;
 	}
 }

--- a/tests/unit/S3ModuleTest.php
+++ b/tests/unit/S3ModuleTest.php
@@ -202,4 +202,21 @@ class S3ModuleTest extends Unit {
 
 	}
 
+	/**
+	 * @return void
+	 * @throws Exception
+	 * @throws Throwable
+	 */
+	public function testDeleteStorageFile():void {
+		$storage = S3Helper::FileToStorage(Yii::getAlias(self::SAMPLE_FILE_PATH));
+		$result = S3Helper::deleteFile($storage);
+
+		$this::assertEquals($storage->id, $result);
+		$this::assertEquals(true, $storage->deleted);
+
+		$s3 = new S3(['storage' => $storage]);
+		$this->expectException(S3Exception::class);
+		$s3->getObject(null, null, PathHelper::GetTempFileName());
+	}
+
 }


### PR DESCRIPTION
На практике удаление какого-либо файла сопровождается предварительным поиском записи в CloudStorage. 
В таком случае гораздо проще и эффективнее передать в метод эту модель, а не делать запрос-дубликат внутри метода на поиск записи в таблице.