### PR TITLE
bitnami/minio -> minio/minio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Create MinIO buckets
         run: |
-          docker run --rm --network host minio/mc:latest /bin/sh -c "
+          docker run --rm --network host --entrypoint /bin/sh minio/mc:latest -c "
             mc alias set local http://127.0.0.1:9000 minioadmin minioadmin &&
             mc mb -p local/testbucket local/first-bucket local/second-bucket
           "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,25 +33,27 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-      
-      minio:
-        image: bitnami/minio:latest
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin
-          MINIO_DEFAULT_BUCKETS: testbucket,first-bucket,second-bucket
-        ports:
-          - 9000:9000
-          - 9001:9001
-        options: >-
-          --health-cmd "curl -f http://localhost:9000/minio/health/live || exit 1"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio \
+            -p 9000:9000 -p 9001:9001 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:latest server /data --console-address ":9001"
+
+          timeout 30 bash -c 'until curl -fs http://127.0.0.1:9000/minio/health/live; do sleep 1; done'
+
+      - name: Create MinIO buckets
+        run: |
+          docker run --rm --network host minio/mc:latest /bin/sh -c "
+            mc alias set local http://127.0.0.1:9000 minioadmin minioadmin &&
+            mc mb -p local/testbucket local/first-bucket local/second-bucket
+          "
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -85,10 +87,7 @@ jobs:
       - name: Setup test environment
         run: |
           cp tests/.env.ci tests/.env
-          
-          # Wait for MinIO to be ready (bitnami/minio creates buckets automatically)
-          timeout 30 bash -c 'until curl -f http://127.0.0.1:9000/minio/health/live; do sleep 1; done'
-          
+
           # Verify MinIO is accessible
           curl -I http://127.0.0.1:9000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,12 +22,12 @@ services:
       - yii2-s3-network
 
   minio:
-    image: bitnami/minio:latest
+    image: minio/minio:latest
     container_name: yii2-s3-minio
+    command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
-      MINIO_DEFAULT_BUCKETS: "dev-bucket,testbucket,first-bucket,second-bucket"
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -40,6 +40,21 @@ services:
       retries: 5
     networks:
       - yii2-s3-network
+
+  minio-init:
+    image: minio/mc:latest
+    container_name: yii2-s3-minio-init
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin &&
+      mc mb -p local/dev-bucket local/testbucket local/first-bucket local/second-bucket
+      "
+    networks:
+      - yii2-s3-network
+    restart: "no"
 
   php-8.1:
     build:


### PR DESCRIPTION
minio service now uses `minio/minio:latest` (instead of `bitnami/minio`) with explicit command: `server /data --console-address ":9001"`.
`MINIO_DEFAULT_BUCKETS` removed (unsupported). New `minio-init` sidecar (`minio/mc:latest`) waits for MinIO to be healthy and creates dev-bucket, testbucket, first-bucket, second-bucket via mc mb -p. The -p flag makes it idempotent so make up is safe to re-run.